### PR TITLE
feat: move return_route definition to pickup protocol

### DIFF
--- a/lib/src/mediator_client/mediator_client.dart
+++ b/lib/src/mediator_client/mediator_client.dart
@@ -152,9 +152,6 @@ class MediatorClient {
       recipientDid: actorDidDocument.id,
     );
 
-    // TODO: clarify if return_route is required only by Affinidi mediator
-    setupRequestMessage['return_route'] = 'all';
-
     // TODO: clarify if live delivery is required only by Affinidi mediator
     final liveDeliveryMessage = LiveDeliveryChangeMessage(
       id: Uuid().v4(),
@@ -162,9 +159,6 @@ class MediatorClient {
       from: actorDidDocument.id,
       liveDelivery: true,
     );
-
-    // TODO: clarify if return_route is required only by Affinidi mediator
-    liveDeliveryMessage['return_route'] = 'all';
 
     final liveDeliveryEncryptedMessage = await _signAndEncryptMessage(
       liveDeliveryMessage,

--- a/lib/src/messages/protocols/message_pickup/live_delivery_change_message.dart
+++ b/lib/src/messages/protocols/message_pickup/live_delivery_change_message.dart
@@ -14,7 +14,9 @@ class LiveDeliveryChangeMessage extends PlainTextMessage {
             'https://didcomm.org/messagepickup/3.0/live-delivery-change',
           ),
           body: {'live_delivery': liveDelivery},
-        );
+        ) {
+    this['return_route'] = 'all';
+  }
 
   factory LiveDeliveryChangeMessage.fromJson(Map<String, dynamic> json) {
     final plainTextMessage = PlainTextMessage.fromJson(json);

--- a/lib/src/messages/protocols/message_pickup/status_request_message.dart
+++ b/lib/src/messages/protocols/message_pickup/status_request_message.dart
@@ -14,7 +14,9 @@ class StatusRequestMessage extends PlainTextMessage {
             'https://didcomm.org/messagepickup/3.0/status-request',
           ),
           body: {'recipient_did': recipientDid},
-        );
+        ) {
+    this['return_route'] = 'all';
+  }
 
   factory StatusRequestMessage.fromJson(Map<String, dynamic> json) {
     final plainTextMessage = PlainTextMessage.fromJson(json);


### PR DESCRIPTION
Move `return_route` header to message pickup protocol definition. The message pickup spec describes it as required: https://didcomm.org/messagepickup/3.0/ 