### PR TITLE
docs: readme key types

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The DIDComm for Dart package utilises existing open standards and cryptographic 
 
 - Support for digital wallets under [Affinidi Dart SSI](https://pub.dev/packages/ssi) to manage cryptographic keys.
 
-- Support key types like `P256`, `ED25519` and `SECP256k1` to encrypt and sign messages.
+- Support key types like `P256`, `ED25519` and `SECP256K1` to encrypt and sign messages.
 
 - Connect and authenticate with different mediator services that follow the DIDComm Message v2.0 protocol.
 


### PR DESCRIPTION
Updated readme to include SECP256K1 in the supported key types