### PR TITLE
chore: add web support

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,6 +6,14 @@ repository: https://github.com/affinidi/affinidi-didcomm-dart
 environment:
   sdk: ^3.6.0
 
+platforms:
+  web:
+  android:
+  ios:
+  linux:
+  macos:
+  windows:
+
 dependencies:
   analyzer: ^7.4.5
   build: ^2.4.2


### PR DESCRIPTION
dart pub publish --dry-run does not report any issues pointing to platforms, so I hope it should work and add WEB on pubdev