### PR TITLE
feat: forward message abstracted in mediator client

### DIFF
--- a/example/didcomm_mediator_example.dart
+++ b/example/didcomm_mediator_example.dart
@@ -135,7 +135,7 @@ void main() async {
     ),
     didKeyId: aliceMatchedKeyIds.first,
     signer: aliceSigner,
-    forwardMessageOptions: const ForwardMessageOptions(
+    plainTextMessageOptions: const PlainTextMessageOptions(
       shouldSign: true,
       shouldEncrypt: true,
       keyWrappingAlgorithm: KeyWrappingAlgorithm.ecdhEs,

--- a/example/didcomm_mediator_sender_example.dart
+++ b/example/didcomm_mediator_sender_example.dart
@@ -156,7 +156,7 @@ void main() async {
     didKeyId: senderMatchedDidKeyIds.first,
     signer: senderSigner,
     // optional. if omitted defaults will be used
-    forwardMessageOptions: const ForwardMessageOptions(
+    plainTextMessageOptions: const PlainTextMessageOptions(
       shouldSign: true,
       shouldEncrypt: true,
       keyWrappingAlgorithm: KeyWrappingAlgorithm.ecdhEs,

--- a/example/didcomm_mediator_web_sockets_example.dart
+++ b/example/didcomm_mediator_web_sockets_example.dart
@@ -151,7 +151,7 @@ void main() async {
       signer: aliceSigner,
 
       // optional. if omitted defaults will be used
-      forwardMessageOptions: const ForwardMessageOptions(
+      plainTextMessageOptions: const PlainTextMessageOptions(
         shouldSign: true,
         shouldEncrypt: true,
         keyWrappingAlgorithm: KeyWrappingAlgorithm.ecdhEs,

--- a/lib/src/mediator_client.dart
+++ b/lib/src/mediator_client.dart
@@ -1,6 +1,6 @@
 export 'mediator_client/mediator_client.dart';
-export 'mediator_client/options/forward_message_options.dart';
 export 'mediator_client/options/live_delivery_change_message_options.dart';
 export 'mediator_client/options/message_options.dart';
+export 'mediator_client/options/plain_text_message_options.dart';
 export 'mediator_client/options/status_request_message_options.dart';
 export 'mediator_client/options/web_socket_options.dart';

--- a/lib/src/mediator_client/mediator_client.dart
+++ b/lib/src/mediator_client/mediator_client.dart
@@ -28,8 +28,8 @@ class MediatorClient {
   /// The signer used for signing messages.
   final DidSigner signer;
 
-  /// Options for forwarding messages to the mediator.
-  final ForwardMessageOptions forwardMessageOptions;
+  /// Options for [PlainTextMessage] messages, sent to the mediator.
+  final PlainTextMessageOptions plainTextMessageOptions;
 
   /// Options for WebSocket connections.
   final WebSocketOptions webSocketOptions;
@@ -43,14 +43,14 @@ class MediatorClient {
   /// [keyPair] - The key pair for encryption/signing.
   /// [didKeyId] - The key ID for encryption.
   /// [signer] - The signer for signing messages.
-  /// [forwardMessageOptions] - Options for forwarding messages (default: const ForwardMessageOptions()).
+  /// [plainTextMessageOptions] - Options for sent messages (default: const PlainTextMessageOptions()).
   /// [webSocketOptions] - Options for WebSocket/live delivery (default: const WebSocketOptions()).
   MediatorClient({
     required this.mediatorDidDocument,
     required this.keyPair,
     required this.didKeyId,
     required this.signer,
-    this.forwardMessageOptions = const ForwardMessageOptions(),
+    this.plainTextMessageOptions = const PlainTextMessageOptions(),
     this.webSocketOptions = const WebSocketOptions(),
   }) : _dio = mediatorDidDocument.toDio(
           mediatorServiceType: DidDocumentServiceType.didCommMessaging,
@@ -78,19 +78,19 @@ class MediatorClient {
     );
   }
 
-  /// Sends a [ForwardMessage] to the mediator.
+  /// Sends a [PlainTextMessage] to the mediator.
   ///
   /// [message] - The message to send.
   /// [accessToken] - Optional bearer token for authentication.
   ///
   /// Returns the packed [DidcommMessage] that was sent.
   Future<DidcommMessage> sendMessage(
-    ForwardMessage message, {
+    PlainTextMessage message, {
     String? accessToken,
   }) async {
     final messageToSend = await _packMessage(
       message,
-      messageOptions: forwardMessageOptions,
+      messageOptions: plainTextMessageOptions,
     );
 
     final headers =

--- a/lib/src/mediator_client/options/plain_text_message_options.dart
+++ b/lib/src/mediator_client/options/plain_text_message_options.dart
@@ -1,16 +1,16 @@
-import 'message_options.dart';
+import '../../../didcomm.dart';
 
-/// Options for sending a forward message over a DIDComm mediator or next hop.
+/// Options for sending a [PlainTextMessage] message over a DIDComm mediator or next hop.
 ///
-/// Allows configuration of how the forward message should be protected (signing, encryption, etc).
-class ForwardMessageOptions extends MessageOptions {
-  /// Constructs [ForwardMessageOptions].
+/// Allows configuration of how the message should be protected (signing, encryption, etc).
+class PlainTextMessageOptions extends MessageOptions {
+  /// Constructs [PlainTextMessageOptions].
   ///
   /// [shouldSign]: Whether the message should be signed (inherited from [MessageOptions]).
   /// [shouldEncrypt]: Whether the message should be encrypted (inherited from [MessageOptions]).
   /// [keyWrappingAlgorithm]: The key wrapping algorithm to use (inherited from [MessageOptions]).
   /// [encryptionAlgorithm]: The encryption algorithm to use (inherited from [MessageOptions]).
-  const ForwardMessageOptions({
+  const PlainTextMessageOptions({
     super.shouldSign,
     super.shouldEncrypt,
     super.keyWrappingAlgorithm,

--- a/lib/src/messages/didcomm_message.dart
+++ b/lib/src/messages/didcomm_message.dart
@@ -329,6 +329,8 @@ abstract class DidcommMessage {
           .toSet();
 
       if (!actualSignerSet.containsAll(expectedSigners)) {
+        prettyPrint('actualSignerSet', object: actualSignerSet.toString());
+        prettyPrint('expectedSigners', object: expectedSigners.toString());
         throw ArgumentError(
           'Can not match expected signers: ${expectedSignerSet.difference(actualSignerSet)}',
           'message',

--- a/test/mediator_integration_test.dart
+++ b/test/mediator_integration_test.dart
@@ -155,7 +155,7 @@ void main() async {
             signer: await aliceDidManager.getSigner(
               aliceDidDocument.authentication.first.id,
             ),
-            forwardMessageOptions: const ForwardMessageOptions(
+            plainTextMessageOptions: const PlainTextMessageOptions(
               shouldSign: true,
               shouldEncrypt: true,
               keyWrappingAlgorithm: KeyWrappingAlgorithm.ecdhEs,


### PR DESCRIPTION
To allow external usage of mediator client by custom protocols, forward message was change to plain text message.