### PR TITLE
fix: enforce recipient DID ownership check during encrypted message unpacking

### DIFF
--- a/lib/src/extensions/did_manager_extension.dart
+++ b/lib/src/extensions/did_manager_extension.dart
@@ -20,13 +20,27 @@ extension DidManagerExtension on DidManager {
   /// Retrieves the wallet key associated with the given [didKeyId] universally.
   ///
   /// Tries to find the key by the fully qualified DID key ID first.
-  /// If not found, tries to find by the fragment after the hash sign.
+  /// If not found, falls back to the fragment after the hash sign, but only
+  /// when the DID base of [didKeyId] matches this manager's own DID.
+  /// This prevents a foreign DID URL (e.g. `did:example:mallory#key-2`) from
+  /// resolving to a local wallet key via fragment-only matching.
   ///
   /// Returns a [String] containing the wallet key if found, or `null` if no key is associated
   /// with the provided [didKeyId].
   Future<String?> getWalletKeyIdUniversally(String didKeyId) async {
     var keyId = await getWalletKeyId(didKeyId);
-    keyId ??= await getWalletKeyId(getKeyIdFromId(didKeyId));
+
+    if (keyId == null) {
+      final didBase = getDidFromId(didKeyId);
+      final isFullyQualified = didBase.startsWith('did:');
+
+      if (isFullyQualified) {
+        final ownDid = (await getDidDocument()).id;
+        if (didBase != ownDid) return null;
+      }
+
+      keyId = await getWalletKeyId(getKeyIdFromId(didKeyId));
+    }
 
     return keyId;
   }

--- a/lib/src/messages/core/encrypted_message/encrypted_message.dart
+++ b/lib/src/messages/core/encrypted_message/encrypted_message.dart
@@ -305,7 +305,13 @@ class EncryptedMessage extends DidcommMessage {
   }
 
   Future<Recipient> _findSelfAsRecipient(DidManager didManager) async {
+    final ownDid = (await didManager.getDidDocument()).id;
+
     for (final recipient in recipients) {
+      final recipientDid = getDidFromId(recipient.header.keyId);
+
+      if (recipientDid != ownDid) continue;
+
       final keyId = await didManager.getWalletKeyIdUniversally(
         recipient.header.keyId,
       );

--- a/test/security/recipient_did_confusion_fix_test.dart
+++ b/test/security/recipient_did_confusion_fix_test.dart
@@ -1,0 +1,224 @@
+import 'package:didcomm/didcomm.dart';
+import 'package:ssi/ssi.dart';
+import 'package:test/test.dart';
+
+/// Fix PoC for the reported DID confusion proof of concept.
+///
+/// These tests mirror the report's exact attack scenarios and confirm that
+/// the fix correctly rejects messages addressed to a foreign DID, even when
+/// the key fragment matches a local wallet key.
+void main() {
+  group('recipient DID confusion — fix verification (counter-PoC)', () {
+    test(
+        'anoncrypt rejects a did:peer recipient as did:example when the key fragment matches',
+        () async {
+      final victim = await _createDidPeerRecipient();
+      final fakeRecipientDidDocument = _cloneWithForeignDid(
+        victim.didDocument,
+        foreignDid: 'did:example:mallory',
+      );
+      final plaintext = PlainTextMessage(
+        id: 'anoncrypt-poc',
+        type: Uri.parse('https://didcomm.org/test/1.0/msg'),
+        to: [fakeRecipientDidDocument.id],
+        body: {'content': 'cross-did anoncrypt delivery'},
+      );
+
+      final encrypted = await DidcommMessage.packIntoEncryptedMessage(
+        plaintext,
+        keyType: KeyType.p256,
+        recipientDidDocuments: [fakeRecipientDidDocument],
+        keyWrappingAlgorithm: KeyWrappingAlgorithm.ecdhEs,
+        encryptionAlgorithm: EncryptionAlgorithm.a256cbc,
+      );
+
+      // The attacker's message is addressed to a foreign DID
+      expect(victim.didDocument.id, isNot(fakeRecipientDidDocument.id));
+      expect(encrypted.recipients.single.header.keyId,
+          'did:example:mallory#key-2');
+
+      // The victim rejects the message
+      await expectLater(
+        DidcommMessage.unpackToPlainTextMessage(
+          message: encrypted.toJson(),
+          recipientDidManager: victim.didManager,
+          expectedMessageWrappingTypes: [MessageWrappingType.anoncryptPlaintext],
+        ),
+        throwsA(
+          isA<Exception>().having(
+            (e) => e.toString(),
+            'message',
+            contains('Self recipient not found'),
+          ),
+        ),
+      );
+    });
+
+    test(
+        'authcrypt rejects a did:peer recipient as did:example when the key fragment matches',
+        () async {
+      final victim = await _createDidPeerRecipient();
+      final fakeRecipientDidDocument = _cloneWithForeignDid(
+        victim.didDocument,
+        foreignDid: 'did:example:mallory',
+      );
+      final sender = await _createDidKeySender();
+
+      final plaintext = PlainTextMessage(
+        id: 'authcrypt-poc',
+        type: Uri.parse('https://didcomm.org/test/1.0/msg'),
+        from: sender.didDocument.id,
+        to: [fakeRecipientDidDocument.id],
+        body: {'content': 'cross-did authcrypt delivery'},
+      );
+
+      final encrypted = await DidcommMessage.packIntoEncryptedMessage(
+        plaintext,
+        keyPair: sender.keyPair,
+        didKeyId: sender.didDocument.keyAgreement.first.didKeyId,
+        recipientDidDocuments: [fakeRecipientDidDocument],
+        keyWrappingAlgorithm: KeyWrappingAlgorithm.ecdh1Pu,
+        encryptionAlgorithm: EncryptionAlgorithm.a256cbc,
+      );
+
+      // The attacker's message is addressed to a foreign DID
+      expect(victim.didDocument.id, isNot(fakeRecipientDidDocument.id));
+      expect(encrypted.recipients.single.header.keyId,
+          'did:example:mallory#key-2');
+
+      // The victim rejects the message
+      await expectLater(
+        DidcommMessage.unpackToPlainTextMessage(
+          message: encrypted.toJson(),
+          recipientDidManager: victim.didManager,
+          expectedMessageWrappingTypes: [
+            MessageWrappingType.authcryptPlaintext,
+          ],
+        ),
+        throwsA(
+          isA<Exception>().having(
+            (e) => e.toString(),
+            'message',
+            contains('Self recipient not found'),
+          ),
+        ),
+      );
+    });
+
+    test('legitimate anoncrypt still works', () async {
+      final victim = await _createDidPeerRecipient();
+      final plaintext = PlainTextMessage(
+        id: 'legit-anoncrypt',
+        type: Uri.parse('https://didcomm.org/test/1.0/msg'),
+        to: [victim.didDocument.id],
+        body: {'content': 'legitimate anoncrypt delivery'},
+      );
+
+      final encrypted = await DidcommMessage.packIntoEncryptedMessage(
+        plaintext,
+        keyType: KeyType.p256,
+        recipientDidDocuments: [victim.didDocument],
+        keyWrappingAlgorithm: KeyWrappingAlgorithm.ecdhEs,
+        encryptionAlgorithm: EncryptionAlgorithm.a256cbc,
+      );
+
+      final unpacked = await DidcommMessage.unpackToPlainTextMessage(
+        message: encrypted.toJson(),
+        recipientDidManager: victim.didManager,
+        expectedMessageWrappingTypes: [MessageWrappingType.anoncryptPlaintext],
+      );
+
+      expect(unpacked.to, [victim.didDocument.id]);
+      expect(unpacked.body?['content'], 'legitimate anoncrypt delivery');
+    });
+
+    test('legitimate authcrypt still works', () async {
+      final victim = await _createDidPeerRecipient();
+      final sender = await _createDidKeySender();
+
+      final plaintext = PlainTextMessage(
+        id: 'legit-authcrypt',
+        type: Uri.parse('https://didcomm.org/test/1.0/msg'),
+        from: sender.didDocument.id,
+        to: [victim.didDocument.id],
+        body: {'content': 'legitimate authcrypt delivery'},
+      );
+
+      final encrypted = await DidcommMessage.packIntoEncryptedMessage(
+        plaintext,
+        keyPair: sender.keyPair,
+        didKeyId: sender.didDocument.keyAgreement.first.didKeyId,
+        recipientDidDocuments: [victim.didDocument],
+        keyWrappingAlgorithm: KeyWrappingAlgorithm.ecdh1Pu,
+        encryptionAlgorithm: EncryptionAlgorithm.a256cbc,
+      );
+
+      final unpacked = await DidcommMessage.unpackToPlainTextMessage(
+        message: encrypted.toJson(),
+        recipientDidManager: victim.didManager,
+        expectedMessageWrappingTypes: [MessageWrappingType.authcryptPlaintext],
+      );
+
+      expect(unpacked.to, [victim.didDocument.id]);
+      expect(unpacked.from, sender.didDocument.id);
+      expect(unpacked.body?['content'], 'legitimate authcrypt delivery');
+    });
+  });
+}
+
+Future<({DidDocument didDocument, DidPeerManager didManager})>
+    _createDidPeerRecipient() async {
+  final wallet = PersistentWallet(InMemoryKeyStore());
+  final didManager = DidPeerManager(
+    wallet: wallet,
+    store: InMemoryDidStore(),
+  );
+
+  await wallet.generateKey(
+    keyId: 'victim-p256',
+    keyType: KeyType.p256,
+  );
+  await didManager.addVerificationMethod('victim-p256');
+
+  return (
+    didDocument: await didManager.getDidDocument(),
+    didManager: didManager,
+  );
+}
+
+Future<({DidDocument didDocument, DidKeyManager didManager, KeyPair keyPair})>
+    _createDidKeySender() async {
+  final wallet = PersistentWallet(InMemoryKeyStore());
+  final didManager = DidKeyManager(
+    wallet: wallet,
+    store: InMemoryDidStore(),
+  );
+  final keyPair = await wallet.generateKey(
+    keyId: 'sender-p256',
+    keyType: KeyType.p256,
+  );
+  await didManager.addVerificationMethod('sender-p256');
+
+  return (
+    didDocument: await didManager.getDidDocument(),
+    didManager: didManager,
+    keyPair: keyPair,
+  );
+}
+
+DidDocument _cloneWithForeignDid(
+  DidDocument didDocument, {
+  required String foreignDid,
+}) {
+  final json = Map<String, dynamic>.from(didDocument.toJson());
+  json['id'] = foreignDid;
+
+  final verificationMethods =
+      (json['verificationMethod'] as List).cast<Map<String, dynamic>>();
+
+  for (final verificationMethod in verificationMethods) {
+    verificationMethod['controller'] = foreignDid;
+  }
+
+  return DidDocument.fromJson(json);
+}

--- a/test/security/recipient_did_confusion_poc_test.dart
+++ b/test/security/recipient_did_confusion_poc_test.dart
@@ -1,0 +1,140 @@
+import 'package:didcomm/didcomm.dart';
+import 'package:ssi/ssi.dart';
+import 'package:test/test.dart';
+
+/// Reported original proof of concept — demonstrates the vulnerability.
+///
+/// These tests reproduce the recipient DID confusion attack. Before the fix,
+/// both tests PASSED (the victim accepted messages addressed to a foreign DID).
+/// After the fix, both tests FAIL — confirming the vulnerability is closed.
+void main() {
+  group('recipient DID confusion proof of concept', () {
+    test('anoncrypt accepts a did:peer recipient as did:example when the key fragment matches', () async {
+      final victim = await _createDidPeerRecipient();
+      final fakeRecipientDidDocument = _cloneWithForeignDid(
+        victim.didDocument,
+        foreignDid: 'did:example:mallory',
+      );
+      final plaintext = PlainTextMessage(
+        id: 'anoncrypt-poc',
+        type: Uri.parse('https://didcomm.org/test/1.0/msg'),
+        to: [fakeRecipientDidDocument.id],
+        body: {'content': 'cross-did anoncrypt delivery'},
+      );
+
+      final encrypted = await DidcommMessage.packIntoEncryptedMessage(
+        plaintext,
+        keyType: KeyType.p256,
+        recipientDidDocuments: [fakeRecipientDidDocument],
+        keyWrappingAlgorithm: KeyWrappingAlgorithm.ecdhEs,
+        encryptionAlgorithm: EncryptionAlgorithm.a256cbc,
+      );
+
+      final unpacked = await DidcommMessage.unpackToPlainTextMessage(
+        message: encrypted.toJson(),
+        recipientDidManager: victim.didManager,
+        expectedMessageWrappingTypes: [MessageWrappingType.anoncryptPlaintext],
+      );
+
+      expect(victim.didDocument.id, isNot(fakeRecipientDidDocument.id));
+      expect(encrypted.recipients.single.header.keyId, 'did:example:mallory#key-2');
+      expect(unpacked.to, [fakeRecipientDidDocument.id]);
+      expect(unpacked.body?['content'], 'cross-did anoncrypt delivery');
+    });
+
+    test('authcrypt accepts a did:peer recipient as did:example when the key fragment matches', () async {
+      final victim = await _createDidPeerRecipient();
+      final fakeRecipientDidDocument = _cloneWithForeignDid(
+        victim.didDocument,
+        foreignDid: 'did:example:mallory',
+      );
+      final sender = await _createDidKeySender();
+
+      final plaintext = PlainTextMessage(
+        id: 'authcrypt-poc',
+        type: Uri.parse('https://didcomm.org/test/1.0/msg'),
+        from: sender.didDocument.id,
+        to: [fakeRecipientDidDocument.id],
+        body: {'content': 'cross-did authcrypt delivery'},
+      );
+
+      final encrypted = await DidcommMessage.packIntoEncryptedMessage(
+        plaintext,
+        keyPair: sender.keyPair,
+        didKeyId: sender.didDocument.keyAgreement.first.didKeyId,
+        recipientDidDocuments: [fakeRecipientDidDocument],
+        keyWrappingAlgorithm: KeyWrappingAlgorithm.ecdh1Pu,
+        encryptionAlgorithm: EncryptionAlgorithm.a256cbc,
+      );
+
+      final unpacked = await DidcommMessage.unpackToPlainTextMessage(
+        message: encrypted.toJson(),
+        recipientDidManager: victim.didManager,
+        expectedMessageWrappingTypes: [MessageWrappingType.authcryptPlaintext],
+      );
+
+      expect(victim.didDocument.id, isNot(fakeRecipientDidDocument.id));
+      expect(encrypted.recipients.single.header.keyId, 'did:example:mallory#key-2');
+      expect(unpacked.to, [fakeRecipientDidDocument.id]);
+      expect(unpacked.from, sender.didDocument.id);
+      expect(unpacked.body?['content'], 'cross-did authcrypt delivery');
+    });
+  });
+}
+
+Future<({DidDocument didDocument, DidPeerManager didManager})>
+    _createDidPeerRecipient() async {
+  final wallet = PersistentWallet(InMemoryKeyStore());
+  final didManager = DidPeerManager(
+    wallet: wallet,
+    store: InMemoryDidStore(),
+  );
+
+  await wallet.generateKey(
+    keyId: 'victim-p256',
+    keyType: KeyType.p256,
+  );
+  await didManager.addVerificationMethod('victim-p256');
+
+  return (
+    didDocument: await didManager.getDidDocument(),
+    didManager: didManager,
+  );
+}
+
+Future<({DidDocument didDocument, DidKeyManager didManager, KeyPair keyPair})>
+    _createDidKeySender() async {
+  final wallet = PersistentWallet(InMemoryKeyStore());
+  final didManager = DidKeyManager(
+    wallet: wallet,
+    store: InMemoryDidStore(),
+  );
+  final keyPair = await wallet.generateKey(
+    keyId: 'sender-p256',
+    keyType: KeyType.p256,
+  );
+  await didManager.addVerificationMethod('sender-p256');
+
+  return (
+    didDocument: await didManager.getDidDocument(),
+    didManager: didManager,
+    keyPair: keyPair,
+  );
+}
+
+DidDocument _cloneWithForeignDid(
+  DidDocument didDocument, {
+  required String foreignDid,
+}) {
+  final json = Map<String, dynamic>.from(didDocument.toJson());
+  json['id'] = foreignDid;
+
+  final verificationMethods =
+      (json['verificationMethod'] as List).cast<Map<String, dynamic>>();
+
+  for (final verificationMethod in verificationMethods) {
+    verificationMethod['controller'] = foreignDid;
+  }
+
+  return DidDocument.fromJson(json);
+}


### PR DESCRIPTION
## Summary

- Enforce DID ownership check in `_findSelfAsRecipient()` — reject recipients whose kid DID base doesn't match the local DID manager's own DID
- Harden `getWalletKeyIdUniversally()` — block fragment-only fallback for foreign DID URLs
- Add security tests reproducing the reported vulnerability and verifying the fix

## Context

A recipient confusion vulnerability allowed a did:peer recipient to decrypt and accept DIDComm encrypted messages addressed to a foreign DID (e.g. `did:example:mallory`), when the key fragment matched a local wallet key. This affected both anoncrypt (ECDH-ES) and authcrypt (ECDH-1PU) flows.

## Test plan

- [ ] Reporter's PoC now fails (attack blocked)
- [ ] Counter-PoC passes (attack rejected + legitimate flows work)
- [ ] Existing test suite passes (131 tests, zero regressions)

Run: `dart test test/security/ -r expanded`