### PR TITLE
fix: update ssi dependency to version 3.9.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   elliptic: ^0.3.11
   json_annotation: ^4.9.0
   pointycastle: ^4.0.0
-  ssi: ^3.0.2
+  ssi: ^3.9.0
   synchronized: ^3.3.0+3
   uuid: ^4.5.1
   web_socket_channel: ^3.0.3


### PR DESCRIPTION
This pull request updates the `ssi` dependency to a newer version in the `pubspec.yaml` file.

Dependency updates:

* Upgraded the `ssi` package from version `^3.0.2` to `^3.9.0` to incorporate the latest features and fixes.