### PR TITLE
fix: new mediator migration

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -6,9 +6,6 @@ env:
   TEST_ALICE_PRIVATE_KEY_PEM: ${{ vars.TEST_ALICE_PRIVATE_KEY_PEM }}
   TEST_BOB_PRIVATE_KEY_PEM: ${{ vars.TEST_BOB_PRIVATE_KEY_PEM }}
 jobs:
-  wiz-scan:
-    uses: affinidi/pipeline-security/.github/workflows/wizcli-dirscan.yml@main
-    secrets: inherit
   build:
     runs-on: ubuntu-latest
     services:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       localstack:
-        image: localstack/localstack:latest
+        image: localstack/localstack:4.14.0
         ports:
           - 4566:4566
         options: --env KMS=true

--- a/lib/src/mediator_client/connection.dart
+++ b/lib/src/mediator_client/connection.dart
@@ -167,6 +167,13 @@ class Connection {
                 .webSocketOptions.liveDeliveryChangeMessageOptions,
           ),
         );
+
+        // give the mediator time to activate live delivery before any
+        // subsequent message is forwarded, otherwise a message can land in the
+        // inbox before live delivery is active and never be pushed over the
+        // WebSocket
+        // TODO: remove this delay once we process acknowledgment of the live-delivery-change message
+        await Future<void>.delayed(const Duration(seconds: 2));
       }
 
       if (_mediatorClient.webSocketOptions.fetchMessagesOnConnect) {

--- a/lib/src/mediator_client/connection.dart
+++ b/lib/src/mediator_client/connection.dart
@@ -167,33 +167,80 @@ class Connection {
                 .webSocketOptions.liveDeliveryChangeMessageOptions,
           ),
         );
-
-        // give the mediator time to activate live delivery before any
-        // subsequent message is forwarded, otherwise a message can land in the
-        // inbox before live delivery is active and never be pushed over the
-        // WebSocket
-        // TODO: remove this delay once we process acknowledgment of the live-delivery-change message
-        await Future<void>.delayed(const Duration(milliseconds: 250));
       }
 
       if (_mediatorClient.webSocketOptions.fetchMessagesOnConnect) {
-        // fetch messages that were sent before the WebSocket connection was established
-        unawaited(
-          _mediatorClient
-              .fetchMessages(
-                  deleteOnMediator:
-                      _mediatorClient.webSocketOptions.deleteOnReceive)
-              .then((messages) async {
-            for (final message in messages) {
-              // prevent connection from being closed while processing messages
-              await _lock.synchronized(() async {
-                _controller.add(message);
-              });
+        // Messages forwarded to the inbox around the time the WebSocket
+        // connection is being established may not be pushed over the socket
+        // via live delivery, so they would otherwise stay in the inbox until
+        // the next (re)connect. To cover that window we poll the inbox a few
+        // times right after connecting and push any queued messages into the
+        // stream.
+        // TODO: the proper solution would be to wait for the live delivery
+        // status message from the mediator and only then fetch all messages.
+        // However, this requires significant refactoring since the DidManager,
+        // needed to unpack the status message, is not available at the
+        // connection level.
+        unawaited(drainInboxMessages(
+          listMessageIds: _mediatorClient.listInboxMessageIds,
+          fetchMessagesByIds: (ids) => _mediatorClient.fetchMessagesByIds(
+            ids,
+            deleteOnMediator: _mediatorClient.webSocketOptions.deleteOnReceive,
+          ),
+          emit: (message) => _lock.synchronized(() async {
+            if (channel == null) {
+              // connection has been stopped
+              return;
             }
+
+            _controller.add(message);
           }),
-        );
+          isActive: () => channel != null,
+        ));
       }
     });
+  }
+
+  /// Polls the mediator inbox up to [maxAttempts] times, [interval] apart, and
+  /// emits any not-yet-seen messages via [emit].
+  ///
+  /// Messages are deduplicated by their inbox message id, so a message that is
+  /// still returned by a later poll (e.g. when messages are not deleted on the
+  /// mediator) is emitted only once. Polling stops early once [isActive]
+  /// returns false.
+  static Future<void> drainInboxMessages({
+    required Future<List<String>> Function() listMessageIds,
+    required Future<List<Map<String, dynamic>>> Function(List<String> ids)
+        fetchMessagesByIds,
+    required Future<void> Function(Map<String, dynamic> message) emit,
+    required bool Function() isActive,
+    int maxAttempts = 5,
+    Duration interval = const Duration(seconds: 1),
+  }) async {
+    // IDs of messages already added to the stream during polling, used to
+    // avoid emitting the same message twice when it is still returned by a
+    // later poll (e.g. when messages are not deleted on the mediator).
+    final seenMessageIds = <String>{};
+
+    for (var attempt = 0; attempt < maxAttempts; attempt++) {
+      // stop polling once the connection has been stopped
+      if (!isActive()) {
+        break;
+      }
+
+      final messageIds = await listMessageIds();
+      final newMessageIds = messageIds.where(seenMessageIds.add).toList();
+
+      if (newMessageIds.isNotEmpty) {
+        final messages = await fetchMessagesByIds(newMessageIds);
+
+        for (final message in messages) {
+          await emit(message);
+        }
+      }
+
+      await Future<void>.delayed(interval);
+    }
   }
 
   /// Stops the WebSocket connection and closes the message stream.

--- a/lib/src/mediator_client/connection.dart
+++ b/lib/src/mediator_client/connection.dart
@@ -173,7 +173,7 @@ class Connection {
         // inbox before live delivery is active and never be pushed over the
         // WebSocket
         // TODO: remove this delay once we process acknowledgment of the live-delivery-change message
-        await Future<void>.delayed(const Duration(seconds: 2));
+        await Future<void>.delayed(const Duration(milliseconds: 250));
       }
 
       if (_mediatorClient.webSocketOptions.fetchMessagesOnConnect) {

--- a/lib/src/mediator_client/connection.dart
+++ b/lib/src/mediator_client/connection.dart
@@ -49,6 +49,23 @@ class Connection {
   AuthorizationTokens? _authorizationTokens;
   final _lock = Lock();
 
+  /// Inbox message ids that have already been emitted while the post-connect
+  /// inbox drain is running.
+  ///
+  /// Shared between the WebSocket live-delivery path and [drainInboxMessages]
+  /// so that a message delivered over the socket and also still present in the
+  /// inbox (e.g. when `deleteOnReceive` is false) is emitted only once. It is
+  /// only populated while [_isDrainingInbox] is true and cleared once draining
+  /// finishes, so it does not grow for the lifetime of the connection.
+  final _seenMessageIds = <String>{};
+
+  /// Whether the post-connect inbox drain is currently running.
+  ///
+  /// Deduplication between live delivery and the inbox drain is only needed
+  /// while the drain is active, since afterwards live delivery is the only
+  /// source of messages.
+  bool _isDrainingInbox = false;
+
   /// Creates a [Connection] for the given [mediatorClient].
   Connection({
     required MediatorClient mediatorClient,
@@ -86,16 +103,27 @@ class Connection {
           // prevent connection from being closed while processing messages
           await _lock.synchronized(() async {
             final json = data as String;
+            final messageIdOnMediator = hex.encode(
+              sha256Hash(
+                utf8.encode(json),
+              ),
+            );
 
             if (_mediatorClient.webSocketOptions.deleteOnReceive) {
-              final messageIdOnMediator = hex.encode(
-                sha256Hash(
-                  utf8.encode(json),
-                ),
-              );
               unawaited(_mediatorClient.deleteMessages(
                 messageIds: [messageIdOnMediator],
               ).catchError(_controller.addError));
+            }
+
+            // A message may be delivered both over the WebSocket (live
+            // delivery) and fetched from the inbox by [drainInboxMessages]
+            // while the post-connect inbox drain is running (e.g. when
+            // deleteOnReceive is false and the message is not removed from the
+            // inbox). Deduplicate by the inbox message id only during that
+            // window; once the drain has finished, live delivery is the only
+            // source, so we stop tracking ids to avoid unbounded memory growth.
+            if (_isDrainingInbox && !_seenMessageIds.add(messageIdOnMediator)) {
+              return;
             }
 
             _controller.add(
@@ -181,6 +209,13 @@ class Connection {
         // However, this requires significant refactoring since the DidManager,
         // needed to unpack the status message, is not available at the
         // connection level.
+
+        // Deduplicate live-delivered messages against the drained ones only
+        // while the drain is running (see the WebSocket listener above). The
+        // flag is reset and the tracked ids are cleared once draining finishes
+        // to avoid unbounded memory growth.
+        _isDrainingInbox = true;
+
         unawaited(drainInboxMessages(
           listMessageIds: _mediatorClient.listInboxMessageIds,
           fetchMessagesByIds: (ids) => _mediatorClient.fetchMessagesByIds(
@@ -196,7 +231,11 @@ class Connection {
             _controller.add(message);
           }),
           isActive: () => channel != null,
-        ));
+          seenMessageIds: _seenMessageIds,
+        ).whenComplete(() {
+          _isDrainingInbox = false;
+          _seenMessageIds.clear();
+        }));
       }
     });
   }
@@ -204,24 +243,22 @@ class Connection {
   /// Polls the mediator inbox up to [maxAttempts] times, [interval] apart, and
   /// emits any not-yet-seen messages via [emit].
   ///
-  /// Messages are deduplicated by their inbox message id, so a message that is
-  /// still returned by a later poll (e.g. when messages are not deleted on the
-  /// mediator) is emitted only once. Polling stops early once [isActive]
-  /// returns false.
+  /// Messages are deduplicated by their inbox message id using [seenMessageIds]
+  /// (which is mutated as ids are emitted), so a message that is still returned
+  /// by a later poll (e.g. when messages are not deleted on the mediator) is
+  /// emitted only once. The same set can be shared with another source (such as
+  /// the WebSocket live-delivery path) so a message delivered there is not
+  /// emitted again here. Polling stops early once [isActive] returns false.
   static Future<void> drainInboxMessages({
     required Future<List<String>> Function() listMessageIds,
     required Future<List<Map<String, dynamic>>> Function(List<String> ids)
         fetchMessagesByIds,
     required Future<void> Function(Map<String, dynamic> message) emit,
     required bool Function() isActive,
+    required Set<String> seenMessageIds,
     int maxAttempts = 5,
     Duration interval = const Duration(seconds: 1),
   }) async {
-    // IDs of messages already added to the stream during polling, used to
-    // avoid emitting the same message twice when it is still returned by a
-    // later poll (e.g. when messages are not deleted on the mediator).
-    final seenMessageIds = <String>{};
-
     for (var attempt = 0; attempt < maxAttempts; attempt++) {
       // stop polling once the connection has been stopped
       if (!isActive()) {

--- a/lib/src/providers/authorization_provider/affinidi_authorization_provider.dart
+++ b/lib/src/providers/authorization_provider/affinidi_authorization_provider.dart
@@ -39,19 +39,19 @@ class AffinidiAuthorizationProvider extends AuthorizationProvider {
   }) async {
     final ownDidDocument = await didManager.getDidDocument();
 
-    final bobMatchedDidKeyIds = ownDidDocument.matchKeysInKeyAgreement(
+    final matchedDidKeyIds = ownDidDocument.matchKeysInKeyAgreement(
       otherDidDocuments: [
         mediatorDidDocument,
       ],
     );
 
-    if (bobMatchedDidKeyIds.isEmpty) {
+    if (matchedDidKeyIds.isEmpty) {
       throw Exception(
         'No suitable key found for key agreement with the mediator.',
       );
     }
 
-    final didKeyId = bobMatchedDidKeyIds.first;
+    final didKeyId = matchedDidKeyIds.first;
 
     return AffinidiAuthorizationProvider(
       mediatorDidDocument: mediatorDidDocument,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   elliptic: ^0.3.11
   json_annotation: ^4.9.0
   pointycastle: ^4.0.0
-  ssi: ^3.0.2
+  ssi: ^3.9.4
   synchronized: ^3.3.0+3
   uuid: ^4.5.1
   web_socket_channel: ^3.0.3

--- a/test/connection_drain_inbox_test.dart
+++ b/test/connection_drain_inbox_test.dart
@@ -16,6 +16,7 @@ void main() {
 
       final fetchedIdBatches = <List<String>>[];
       final emitted = <Map<String, dynamic>>[];
+      final seenMessageIds = <String>{};
 
       await Connection.drainInboxMessages(
         listMessageIds: () async {
@@ -29,6 +30,7 @@ void main() {
         },
         emit: (message) async => emitted.add(message),
         isActive: () => true,
+        seenMessageIds: seenMessageIds,
         maxAttempts: 3,
         interval: Duration.zero,
       );
@@ -44,11 +46,15 @@ void main() {
         {'id': '1'},
         {'id': '2'},
       ]);
+
+      // every emitted message id is tracked as seen
+      expect(seenMessageIds, {'1', '2'});
     });
 
     test('stops polling once the connection is no longer active', () async {
       var listCalls = 0;
       var active = true;
+      final seenMessageIds = <String>{};
 
       await Connection.drainInboxMessages(
         listMessageIds: () async {
@@ -60,16 +66,21 @@ void main() {
         fetchMessagesByIds: (ids) async => [],
         emit: (message) async {},
         isActive: () => active,
+        seenMessageIds: seenMessageIds,
         maxAttempts: 5,
         interval: Duration.zero,
       );
 
       // the second iteration should break before listing again
       expect(listCalls, 1);
+
+      // nothing was emitted, so no ids are tracked
+      expect(seenMessageIds, isEmpty);
     });
 
     test('does not fetch when the inbox is empty', () async {
       var fetchCalled = false;
+      final seenMessageIds = <String>{};
 
       await Connection.drainInboxMessages(
         listMessageIds: () async => <String>[],
@@ -79,11 +90,66 @@ void main() {
         },
         emit: (message) async {},
         isActive: () => true,
+        seenMessageIds: seenMessageIds,
         maxAttempts: 3,
         interval: Duration.zero,
       );
 
       expect(fetchCalled, isFalse);
+
+      // an empty inbox tracks no ids
+      expect(seenMessageIds, isEmpty);
+    });
+
+    test(
+      'does not emit messages already present in the shared seenMessageIds',
+      () async {
+        // ids '1' and '2' were already delivered over the WebSocket
+        // (live delivery) and recorded in the shared set.
+        final seenMessageIds = <String>{'1', '2'};
+
+        final fetchedIdBatches = <List<String>>[];
+        final emitted = <Map<String, dynamic>>[];
+
+        await Connection.drainInboxMessages(
+          listMessageIds: () async => ['1', '2', '3'],
+          fetchMessagesByIds: (ids) async {
+            fetchedIdBatches.add(ids);
+            return ids.map((id) => <String, dynamic>{'id': id}).toList();
+          },
+          emit: (message) async => emitted.add(message),
+          isActive: () => true,
+          seenMessageIds: seenMessageIds,
+          maxAttempts: 1,
+          interval: Duration.zero,
+        );
+
+        // only the id not already delivered over the socket is fetched/emitted
+        expect(fetchedIdBatches, [
+          ['3'],
+        ]);
+        expect(emitted, [
+          {'id': '3'},
+        ]);
+      },
+    );
+
+    test('records drained ids into the shared seenMessageIds', () async {
+      // the live-delivery path can later skip these ids to avoid duplicates
+      final seenMessageIds = <String>{};
+
+      await Connection.drainInboxMessages(
+        listMessageIds: () async => ['1', '2'],
+        fetchMessagesByIds: (ids) async =>
+            ids.map((id) => <String, dynamic>{'id': id}).toList(),
+        emit: (message) async {},
+        isActive: () => true,
+        seenMessageIds: seenMessageIds,
+        maxAttempts: 1,
+        interval: Duration.zero,
+      );
+
+      expect(seenMessageIds, {'1', '2'});
     });
   });
 }

--- a/test/connection_drain_inbox_test.dart
+++ b/test/connection_drain_inbox_test.dart
@@ -1,0 +1,89 @@
+import 'package:didcomm/src/mediator_client/connection.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Connection.drainInboxMessages', () {
+    test('emits each inbox message once, deduplicating by id across polls',
+        () async {
+      // The mediator keeps returning previously seen ids on later polls
+      // (e.g. when messages are not deleted on the mediator).
+      final inboxByAttempt = <List<String>>[
+        ['1'],
+        ['1', '2'],
+        ['1', '2'],
+      ];
+      var attempt = 0;
+
+      final fetchedIdBatches = <List<String>>[];
+      final emitted = <Map<String, dynamic>>[];
+
+      await Connection.drainInboxMessages(
+        listMessageIds: () async {
+          final ids = inboxByAttempt[attempt];
+          attempt++;
+          return ids;
+        },
+        fetchMessagesByIds: (ids) async {
+          fetchedIdBatches.add(ids);
+          return ids.map((id) => <String, dynamic>{'id': id}).toList();
+        },
+        emit: (message) async => emitted.add(message),
+        isActive: () => true,
+        maxAttempts: 3,
+        interval: Duration.zero,
+      );
+
+      // only not-yet-seen ids are fetched on each poll
+      expect(fetchedIdBatches, [
+        ['1'],
+        ['2'],
+      ]);
+
+      // each message is emitted exactly once despite being listed repeatedly
+      expect(emitted, [
+        {'id': '1'},
+        {'id': '2'},
+      ]);
+    });
+
+    test('stops polling once the connection is no longer active', () async {
+      var listCalls = 0;
+      var active = true;
+
+      await Connection.drainInboxMessages(
+        listMessageIds: () async {
+          listCalls++;
+          // the connection is stopped right after the first poll
+          active = false;
+          return <String>[];
+        },
+        fetchMessagesByIds: (ids) async => [],
+        emit: (message) async {},
+        isActive: () => active,
+        maxAttempts: 5,
+        interval: Duration.zero,
+      );
+
+      // the second iteration should break before listing again
+      expect(listCalls, 1);
+    });
+
+    test('does not fetch when the inbox is empty', () async {
+      var fetchCalled = false;
+
+      await Connection.drainInboxMessages(
+        listMessageIds: () async => <String>[],
+        fetchMessagesByIds: (ids) async {
+          fetchCalled = true;
+          return [];
+        },
+        emit: (message) async {},
+        isActive: () => true,
+        maxAttempts: 3,
+        interval: Duration.zero,
+      );
+
+      expect(fetchCalled, isFalse);
+    });
+  });
+}

--- a/test/mediator_integration_test.dart
+++ b/test/mediator_integration_test.dart
@@ -393,7 +393,7 @@ void main() async {
                   expectedMessageWrappingTypes: isMediatorTelemetryMessage
                       ? [
                           // send by the old mediator
-                          // TODO: remove after immigration to the new mediator is completed
+                          // TODO: remove after migration to the new mediator is completed
                           MessageWrappingType.authcryptSignPlaintext,
                           // send by the new mediator
                           MessageWrappingType.authcryptPlaintext

--- a/test/mediator_integration_test.dart
+++ b/test/mediator_integration_test.dart
@@ -390,16 +390,22 @@ void main() async {
                   message: message,
                   recipientDidManager: bobDidManager,
                   validateAddressingConsistency: true,
-                  expectedMessageWrappingTypes: [
-                    isMediatorTelemetryMessage
-                        ? MessageWrappingType.authcryptSignPlaintext
-                        : MessageWrappingType.anoncryptSignPlaintext,
-                  ],
-                  expectedSigners: [
-                    isMediatorTelemetryMessage
-                        ? bobMediatorDocument.assertionMethod.first.didKeyId
-                        : aliceDidDocument.assertionMethod.first.didKeyId,
-                  ],
+                  expectedMessageWrappingTypes: isMediatorTelemetryMessage
+                      ? [
+                          // send by the old mediator
+                          // TODO: remove after immigration to the new mediator is completed
+                          MessageWrappingType.authcryptSignPlaintext,
+                          // send by the new mediator
+                          MessageWrappingType.authcryptPlaintext
+                        ]
+                      : [
+                          MessageWrappingType.anoncryptSignPlaintext,
+                        ],
+                  expectedSigners: isMediatorTelemetryMessage
+                      ? null
+                      : [
+                          aliceDidDocument.assertionMethod.first.didKeyId,
+                        ],
                 );
 
                 if (isMediatorTelemetryMessage) {
@@ -700,7 +706,7 @@ void main() async {
 
         expect(errors, isEmpty);
       },
-      timeout: const Timeout(Duration(minutes: 2)),
+      timeout: const Timeout(Duration(minutes: 3)),
     );
   });
 }

--- a/test/mediator_integration_test.dart
+++ b/test/mediator_integration_test.dart
@@ -382,8 +382,7 @@ void main() async {
                     .fromJson(encryptedMessage.protected)
                     .subjectKeyId;
 
-                final isMediatorTelemetryMessage =
-                    senderDid?.contains('.affinidi.io') == true;
+                final isMediatorTelemetryMessage = isMediatorDid(senderDid);
 
                 final unpackedMessage =
                     await DidcommMessage.unpackToPlainTextMessage(
@@ -544,7 +543,7 @@ void main() async {
                 ],
               );
 
-              if (unpacked.from?.contains('.affinidi.io') == true) {
+              if (isMediatorDid(unpacked.from)) {
                 return;
               }
 
@@ -601,7 +600,7 @@ void main() async {
                 ],
               );
 
-              if (unpacked.from?.contains('.affinidi.io') == true) {
+              if (isMediatorDid(unpacked.from)) {
                 return;
               }
 
@@ -714,3 +713,7 @@ void main() async {
 void failTest(String message) {
   throw Exception(message);
 }
+
+/// Whether [did] belongs to the mediator (used to identify mediator-originated
+/// messages such as telemetry).
+bool isMediatorDid(String? did) => did?.contains('.affinidi.io') == true;

--- a/test/mediator_integration_test.dart
+++ b/test/mediator_integration_test.dart
@@ -12,6 +12,14 @@ import 'example_configs.dart';
 
 const testRetries = 2;
 
+/// How long to keep listening after the expected message(s) have been received
+/// to make sure the mediator does not deliver the same message again.
+const duplicateDetectionWindow = Duration(seconds: 5);
+
+/// Number of messages used by the tests that verify messages are kept on the
+/// mediator when they are not auto-deleted.
+const keptMessageCount = 3;
+
 void main() async {
   await configureTestFiles();
 
@@ -247,6 +255,14 @@ void main() async {
           );
 
           final messageIds = await bobMediatorClient.listInboxMessageIds();
+
+          expect(
+            findDuplicateIds(messageIds),
+            isEmpty,
+            reason: 'Duplicated message ids in the inbox: '
+                '${findDuplicateIds(messageIds)}',
+          );
+
           final messagesFetchedByIds =
               await bobMediatorClient.fetchMessagesByIds(
             messageIds,
@@ -267,6 +283,17 @@ void main() async {
                 ],
               ),
             ),
+          );
+
+          final duplicatedUnpackedMessageIds = findDuplicateIds(
+            actualUnpackedMessages.map((message) => message.id),
+          );
+
+          expect(
+            duplicatedUnpackedMessageIds,
+            isEmpty,
+            reason:
+                'Duplicated messages fetched: $duplicatedUnpackedMessageIds',
           );
 
           final messagesFetchedByCursor = await bobMediatorClient.fetchMessages(
@@ -318,7 +345,94 @@ void main() async {
             isNotNull,
             reason: 'Sent message not found',
           );
+
+          expect(
+            actualUnpackedMessages.map((message) => message.id),
+            contains(alicePlainTextMessage.id),
+            reason: 'Sent message id was not received',
+          );
         }, retry: testRetries, tags: []);
+
+        test(
+          'REST API keeps messages when they are not auto-deleted',
+          () async {
+            final sentMessageIds = <String>{};
+
+            for (var i = 0; i < keptMessageCount; i++) {
+              final built = await buildForwardMessage(
+                senderDidManager: aliceDidManager,
+                senderDidDocument: aliceDidDocument,
+                recipientDidDocument: bobDidDocument,
+                mediatorDidDocument: bobMediatorDocument,
+                content: const Uuid().v4(),
+              );
+
+              sentMessageIds.add(built.messageId);
+              await aliceMediatorClient.sendMessage(built.forwardMessage);
+            }
+
+            // fetching without deletion must keep the messages on the mediator
+            final firstFetch = await bobMediatorClient.fetchMessages(
+              deleteOnMediator: false,
+            );
+
+            expect(
+              firstFetch.length,
+              keptMessageCount,
+              reason: 'Expected $keptMessageCount messages, '
+                  'but got ${firstFetch.length}',
+            );
+
+            final firstFetchIds = await unpackMessageIds(
+              firstFetch,
+              bobDidManager,
+            );
+
+            expect(
+              findDuplicateIds(firstFetchIds),
+              isEmpty,
+              reason: 'Duplicated messages fetched: '
+                  '${findDuplicateIds(firstFetchIds)}',
+            );
+
+            expect(
+              firstFetchIds.toSet(),
+              sentMessageIds,
+              reason: 'Fetched messages do not match the sent ones',
+            );
+
+            // fetching again must return the same messages since none were
+            // deleted
+            final secondFetch = await bobMediatorClient.fetchMessages(
+              deleteOnMediator: false,
+            );
+
+            final secondFetchIds = await unpackMessageIds(
+              secondFetch,
+              bobDidManager,
+            );
+
+            expect(
+              secondFetchIds.toSet(),
+              firstFetchIds.toSet(),
+              reason: 'Messages changed between fetches without deletion',
+            );
+
+            // finally delete and make sure the inbox is empty
+            final messageIds = await bobMediatorClient.listInboxMessageIds();
+            await bobMediatorClient.deleteMessages(messageIds: messageIds);
+
+            final inboxAfterDeletion =
+                await bobMediatorClient.listInboxMessageIds();
+
+            expect(
+              inboxAfterDeletion,
+              isEmpty,
+              reason: 'Messages were not deleted',
+            );
+          },
+          retry: testRetries,
+        );
 
         test(
           'WebSockets API works correctly',
@@ -373,7 +487,10 @@ void main() async {
             String? actualBodyContent;
             bool? telemetryMessageReceived;
 
-            final completer = Completer<void>();
+            final receivedMessageIds = <String>{};
+            final duplicateMessageIds = <String>[];
+
+            final expectedMessagesReceived = Completer<void>();
 
             bobMediatorClient.listenForIncomingMessages(
               (message) async {
@@ -407,6 +524,11 @@ void main() async {
                         ],
                 );
 
+                // track received message ids to detect duplicated messages
+                if (!receivedMessageIds.add(unpackedMessage.id)) {
+                  duplicateMessageIds.add(unpackedMessage.id);
+                }
+
                 if (isMediatorTelemetryMessage) {
                   telemetryMessageReceived = true;
                 } else {
@@ -415,9 +537,9 @@ void main() async {
                 }
 
                 if (actualBodyContent == expectedBodyContent &&
-                    telemetryMessageReceived == true) {
-                  await ConnectionPool.instance.stopConnections();
-                  completer.complete();
+                    telemetryMessageReceived == true &&
+                    !expectedMessagesReceived.isCompleted) {
+                  expectedMessagesReceived.complete();
                 }
               },
               onError: (Object error) => prettyPrint('error', object: error),
@@ -430,7 +552,12 @@ void main() async {
               forwardMessage,
             );
 
-            await completer.future;
+            await expectedMessagesReceived.future;
+
+            // keep the connection open for a while to make sure the expected
+            // message is not delivered again (no duplicated messages)
+            await Future<void>.delayed(duplicateDetectionWindow);
+
             await ConnectionPool.instance.stopConnections();
 
             expect(
@@ -444,6 +571,181 @@ void main() async {
               isTrue,
               reason: 'No telemetry message',
             );
+
+            expect(
+              receivedMessageIds,
+              contains(alicePlainTextMessage.id),
+              reason: 'Sent message id was not received',
+            );
+
+            expect(
+              duplicateMessageIds,
+              isEmpty,
+              reason: 'Duplicated messages received: $duplicateMessageIds',
+            );
+          },
+          retry: testRetries,
+        );
+
+        test(
+          'WebSockets API keeps messages when they are not auto-deleted',
+          () async {
+            // a dedicated client that does not delete messages on receive,
+            // so they remain available on the mediator after being delivered
+            final bobKeepMessagesClient = await MediatorClient.init(
+              mediatorDidDocument: bobMediatorDocument,
+              didManager: bobDidManager,
+              authorizationProvider: await AffinidiAuthorizationProvider.init(
+                mediatorDidDocument: bobMediatorDocument,
+                didManager: bobDidManager,
+              ),
+              forwardMessageOptions: const ForwardMessageOptions(
+                shouldSign: true,
+                keyWrappingAlgorithm: KeyWrappingAlgorithm.ecdhEs,
+                encryptionAlgorithm: EncryptionAlgorithm.a256cbc,
+              ),
+              webSocketOptions: const WebSocketOptions(
+                deleteOnReceive: false,
+                liveDeliveryChangeMessageOptions:
+                    LiveDeliveryChangeMessageOptions(
+                  shouldSend: true,
+                  shouldSign: true,
+                  keyWrappingAlgorithm: KeyWrappingAlgorithm.ecdhEs,
+                  encryptionAlgorithm: EncryptionAlgorithm.a256cbc,
+                ),
+                statusRequestMessageOptions: StatusRequestMessageOptions(
+                  shouldSend: true,
+                  shouldSign: true,
+                  keyWrappingAlgorithm: KeyWrappingAlgorithm.ecdhEs,
+                  encryptionAlgorithm: EncryptionAlgorithm.a256cbc,
+                ),
+              ),
+            );
+
+            final sentMessageIds = <String>{};
+            final forwardMessages = <ForwardMessage>[];
+            final receivedMessageIds = <String>{};
+            final duplicateMessageIds = <String>[];
+            final allMessagesReceived = Completer<void>();
+
+            // build the messages up front so [sentMessageIds] is fully
+            // populated before the listener evaluates its completion condition
+            for (var i = 0; i < keptMessageCount; i++) {
+              final built = await buildForwardMessage(
+                senderDidManager: aliceDidManager,
+                senderDidDocument: aliceDidDocument,
+                recipientDidDocument: bobDidDocument,
+                mediatorDidDocument: bobMediatorDocument,
+                content: const Uuid().v4(),
+              );
+
+              sentMessageIds.add(built.messageId);
+              forwardMessages.add(built.forwardMessage);
+            }
+
+            bobKeepMessagesClient.listenForIncomingMessages(
+              (message) async {
+                final encryptedMessage = EncryptedMessage.fromJson(message);
+                final senderDid = const JweHeaderConverter()
+                    .fromJson(encryptedMessage.protected)
+                    .subjectKeyId;
+
+                // ignore mediator telemetry messages
+                if (isMediatorDid(senderDid)) {
+                  return;
+                }
+
+                final unpackedMessage =
+                    await DidcommMessage.unpackToPlainTextMessage(
+                  message: message,
+                  recipientDidManager: bobDidManager,
+                  validateAddressingConsistency: true,
+                  expectedMessageWrappingTypes: [
+                    MessageWrappingType.anoncryptSignPlaintext,
+                  ],
+                  expectedSigners: [
+                    aliceDidDocument.assertionMethod.first.didKeyId,
+                  ],
+                );
+
+                // track received message ids to detect duplicated messages
+                if (!receivedMessageIds.add(unpackedMessage.id)) {
+                  duplicateMessageIds.add(unpackedMessage.id);
+                }
+
+                if (sentMessageIds.every(receivedMessageIds.contains) &&
+                    !allMessagesReceived.isCompleted) {
+                  allMessagesReceived.complete();
+                }
+              },
+              onError: (Object error) => prettyPrint('error', object: error),
+              cancelOnError: false,
+            );
+
+            await ConnectionPool.instance.startConnections();
+
+            // send after the connection is established so each message is
+            // pushed via live delivery while also remaining in the inbox
+            // (deleteOnReceive: false) - the scenario where the live-delivery
+            // and inbox-drain paths could otherwise emit the same message twice
+            for (final forwardMessage in forwardMessages) {
+              await aliceMediatorClient.sendMessage(forwardMessage);
+            }
+
+            await allMessagesReceived.future;
+
+            // keep the connection open for a while to make sure the same
+            // messages are not delivered again (no duplicated messages)
+            await Future<void>.delayed(duplicateDetectionWindow);
+
+            await ConnectionPool.instance.stopConnections();
+
+            expect(
+              duplicateMessageIds,
+              isEmpty,
+              reason: 'Duplicated messages received: $duplicateMessageIds',
+            );
+
+            expect(
+              receivedMessageIds,
+              sentMessageIds,
+              reason: 'Received messages do not match the sent ones',
+            );
+
+            // since deleteOnReceive is false, the messages must still be
+            // available on the mediator after being delivered
+            final remainingMessages = await bobKeepMessagesClient.fetchMessages(
+              deleteOnMediator: false,
+            );
+
+            expect(
+              remainingMessages.length,
+              keptMessageCount,
+              reason: 'Expected $keptMessageCount messages to be kept on the '
+                  'mediator, but got ${remainingMessages.length}',
+            );
+
+            final remainingIds = await unpackMessageIds(
+              remainingMessages,
+              bobDidManager,
+            );
+
+            expect(
+              findDuplicateIds(remainingIds),
+              isEmpty,
+              reason: 'Duplicated messages kept on the mediator: '
+                  '${findDuplicateIds(remainingIds)}',
+            );
+
+            expect(
+              remainingIds.toSet(),
+              sentMessageIds,
+              reason: 'Kept messages differ from the sent ones',
+            );
+
+            // clean up the inbox for the following tests
+            final inboxIds = await bobKeepMessagesClient.listInboxMessageIds();
+            await bobKeepMessagesClient.deleteMessages(messageIds: inboxIds);
           },
           retry: testRetries,
         );
@@ -469,6 +771,10 @@ void main() async {
         test('Can connect after connections have been started', () async {
           final aliceCompleter = Completer<PlainTextMessage>();
           final bobCompleter = Completer<PlainTextMessage>();
+
+          final aliceReceivedMessageIds = <String>{};
+          final bobReceivedMessageIds = <String>{};
+          final duplicateMessageIds = <String>[];
 
           final alicePlainTextMessage = PlainTextMessage(
             id: const Uuid().v4(),
@@ -547,6 +853,13 @@ void main() async {
                 return;
               }
 
+              // track received message ids to detect duplicated messages
+              if (!bobReceivedMessageIds.add(unpacked.id)) {
+                duplicateMessageIds.add(unpacked.id);
+              }
+
+              // intentionally not guarding with isCompleted so a duplicated
+              // message fails the test by completing the completer twice
               bobCompleter.complete(unpacked);
             },
             onError: (Object error) async {
@@ -604,6 +917,13 @@ void main() async {
                 return;
               }
 
+              // track received message ids to detect duplicated messages
+              if (!aliceReceivedMessageIds.add(unpacked.id)) {
+                duplicateMessageIds.add(unpacked.id);
+              }
+
+              // intentionally not guarding with isCompleted so a duplicated
+              // message fails the test by completing the completer twice
               aliceCompleter.complete(unpacked);
             },
             onError: (Object error) async {
@@ -628,6 +948,10 @@ void main() async {
           final receivedAliceMessage = await aliceCompleter.future;
           final receivedBobMessage = await bobCompleter.future;
 
+          // keep the connections open for a while to make sure the mediator
+          // does not deliver the same messages again (no duplicated messages)
+          await Future<void>.delayed(duplicateDetectionWindow);
+
           await ConnectionPool.instance.stopConnections();
 
           expect(
@@ -640,6 +964,12 @@ void main() async {
             receivedAliceMessage.id,
             bobPlainTextMessage.id,
             reason: 'Bob did not receive the expected message from Alice',
+          );
+
+          expect(
+            duplicateMessageIds,
+            isEmpty,
+            reason: 'Duplicated messages received: $duplicateMessageIds',
           );
         });
       });
@@ -712,6 +1042,100 @@ void main() async {
 
 void failTest(String message) {
   throw Exception(message);
+}
+
+/// Returns the ids that appear more than once in [ids], preserving the order
+/// in which the duplicates are encountered.
+List<String> findDuplicateIds(Iterable<String> ids) {
+  final seen = <String>{};
+  final duplicates = <String>[];
+
+  for (final id in ids) {
+    if (!seen.add(id)) {
+      duplicates.add(id);
+    }
+  }
+
+  return duplicates;
+}
+
+/// Packs [content] into a signed and encrypted message and wraps it into a
+/// [ForwardMessage] addressed to the recipient's mediator.
+///
+/// Returns the forward message together with the id of the inner plaintext
+/// message so callers can correlate what was sent with what is received.
+Future<({ForwardMessage forwardMessage, String messageId})>
+    buildForwardMessage({
+  required DidManager senderDidManager,
+  required DidDocument senderDidDocument,
+  required DidDocument recipientDidDocument,
+  required DidDocument mediatorDidDocument,
+  required String content,
+}) async {
+  final messageId = const Uuid().v4();
+
+  final plainTextMessage = PlainTextMessage(
+    id: messageId,
+    from: senderDidDocument.id,
+    to: [recipientDidDocument.id],
+    type: Uri.parse('https://didcomm.org/example/1.0/message'),
+    body: {'content': content},
+  );
+
+  final signedAndEncryptedMessage =
+      await DidcommMessage.packIntoSignedAndEncryptedMessages(
+    plainTextMessage,
+    keyType: [recipientDidDocument].getCommonKeyTypesInKeyAgreements().first,
+    recipientDidDocuments: [recipientDidDocument],
+    keyWrappingAlgorithm: KeyWrappingAlgorithm.ecdhEs,
+    encryptionAlgorithm: EncryptionAlgorithm.a256cbc,
+    signer: await senderDidManager.getSigner(
+      senderDidDocument.assertionMethod.first.id,
+    ),
+  );
+
+  final forwardMessage = ForwardMessage(
+    id: const Uuid().v4(),
+    from: senderDidDocument.id,
+    to: [mediatorDidDocument.id],
+    next: recipientDidDocument.id,
+    expiresTime: DateTime.now().toUtc().add(const Duration(seconds: 600)),
+    attachments: [
+      Attachment(
+        mediaType: 'application/json',
+        data: AttachmentData(
+          base64: base64UrlEncodeNoPadding(
+            signedAndEncryptedMessage.toJsonBytes(),
+          ),
+        ),
+      ),
+    ],
+  );
+
+  return (forwardMessage: forwardMessage, messageId: messageId);
+}
+
+/// Unpacks [messages] and returns their DIDComm message ids.
+Future<List<String>> unpackMessageIds(
+  List<Map<String, dynamic>> messages,
+  DidManager recipientDidManager,
+) async {
+  final unpackedMessages = await Future.wait(
+    messages.map(
+      (message) => DidcommMessage.unpackToPlainTextMessage(
+        message: message,
+        recipientDidManager: recipientDidManager,
+        expectedMessageWrappingTypes: [
+          MessageWrappingType.anoncryptSignPlaintext,
+          MessageWrappingType.authcryptSignPlaintext,
+          MessageWrappingType.authcryptPlaintext,
+          MessageWrappingType.anoncryptAuthcryptPlaintext,
+        ],
+      ),
+    ),
+  );
+
+  return unpackedMessages.map((message) => message.id).toList();
 }
 
 /// Whether [did] belongs to the mediator (used to identify mediator-originated


### PR DESCRIPTION
The new mediator does not send signed messages. This PR adjusts the integration test to accept both signed and unsigned messages from the mediator.

Fixes intermittent message loss over WebSocket: messages forwarded to the mediator right as a connection is being established could land in the inbox before live delivery was active and never get pushed over the socket, staying stranded until the next reconnect. On connect, the client now briefly polls the inbox (5 attempts, 1s apart), deduplicates by mediator message id, and pushes any queued messages into the stream so they're delivered reliably.